### PR TITLE
Add latest to v5 redirect

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1511,5 +1511,11 @@
     "playground": {
       "display": "none"
     }
-  }
+  },
+  "redirects": [
+    {
+      "source": "/api-reference/latest/:slug*",
+      "destination": "/api-reference/v5/:slug*"
+    }
+  ]
 }


### PR DESCRIPTION
Add redirect from legacy /api-reference/latest/* URLs to /api-reference/v5/* to fix 404s from Google search results.