### PR TITLE
CX-42003: Document Variables V2 in dashboard service overview

### DIFF
--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -433,28 +433,28 @@ To use the Dashboard service API you need to [create a personal or team API key]
 
 Variables let a dashboard accept user-supplied or query-derived values that are substituted into widget queries at view time. The dashboard payload carries the **V2** variable model (proto package `com.coralogixapis.dashboards.v1.ast.variables_v2`); the older V1 model (`Variable` / `Variable.Definition` / `VariableDefinitionConstant` / `VariableDefinitionMultiSelect`) is still present in the spec for backward compatibility.
 
-A V2 variable (`VariableV2`) has a name, optional display name and description, a [display type](#variabledisplaytypev2), a source that produces its candidate values, and a value selection.
+A `VariableV2` carries: a unique `id` (UUID), `name`, optional `display_name` and `description`, a [display type](#variabledisplaytypev2), a `source` that produces candidate values, a `value` selection, and a `display_full_row` toggle.
 
 ### Source (`VariableSourceV2`)
 
 A `oneof` over three variants:
 
-- **Query** — values come from a Coralogix query against logs, spans, metrics, or DataPrime. Each query variant supports a refresh strategy, optional value-display options (label/value regex), and an "All" option.
-- **Static** — values are an inline list.
-- **Textbox** — value is free-form text entered in the dashboard UI.
+- **`QuerySource`** — values come from a Coralogix query against logs, spans, metrics, or DataPrime. Carries a `refresh_strategy`, `value_display_options` (label/value regex), and an `all_option`.
+- **`StaticSource`** — values are an inline list (with an `all_option`).
+- **`TextboxSource`** — value is free-form text entered in the dashboard UI.
 
-The Query variant itself has four sub-variants (`VariableSourceV2QuerySource*`): `LogsQuery`, `SpansQuery`, `MetricsQuery`, `DataprimeQuery`.
+`QuerySource` has four sub-variants matching its data source: `LogsQuery`, `SpansQuery`, `MetricsQuery`, `DataprimeQuery` (openapi schema names: `VariableSourceV2QuerySourceLogsQuery`, `…SpansQuery`, `…MetricsQuery`, `…DataprimeQuery`).
 
 ### Value (`VariableValueV2`)
 
-A `oneof` describing what the user (or default) has selected:
+A `oneof` over six variants (proto names):
 
-- `SingleString`
-- `SingleNumeric` — plus `SingleNumericValue` for the inner number
-- `MultiString`
-- `Lucene`
-- `Regex`
-- `Interval`
+- `SingleStringValue`
+- `SingleNumericValue`
+- `MultiStringValue` — wraps either an `AllValue`, a `ListValue`, or a `SelectedAllValue`
+- `LuceneQueryValue`
+- `RegexValue`
+- `IntervalValue`
 
 <details>
   <summary>VariableDisplayTypeV2</summary>

--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -428,3 +428,43 @@ To use the Dashboard service API you need to [create a personal or team API key]
 | `AGGREGATION_TYPE_AVG` |
 | `AGGREGATION_TYPE_SUM` |
 </details>
+
+## Variables (V2)
+
+Variables let a dashboard accept user-supplied or query-derived values that are substituted into widget queries at view time. The dashboard payload carries the **V2** variable model (proto package `com.coralogixapis.dashboards.v1.ast.variables_v2`); the older V1 model (`Variable` / `Variable.Definition` / `VariableDefinitionConstant` / `VariableDefinitionMultiSelect`) is still present in the spec for backward compatibility.
+
+A V2 variable (`VariableV2`) has a name, optional display name and description, a [display type](#variabledisplaytypev2), a source that produces its candidate values, and a value selection.
+
+### Source (`VariableSourceV2`)
+
+A `oneof` over three variants:
+
+- **Query** — values come from a Coralogix query against logs, spans, metrics, or DataPrime. Each query variant supports a refresh strategy, optional value-display options (label/value regex), and an "All" option.
+- **Static** — values are an inline list.
+- **Textbox** — value is free-form text entered in the dashboard UI.
+
+The Query variant itself has four sub-variants (`VariableSourceV2QuerySource*`): `LogsQuery`, `SpansQuery`, `MetricsQuery`, `DataprimeQuery`.
+
+### Value (`VariableValueV2`)
+
+A `oneof` describing what the user (or default) has selected:
+
+- `SingleString`
+- `SingleNumeric` — plus `SingleNumericValue` for the inner number
+- `MultiString`
+- `Lucene`
+- `Regex`
+- `Interval`
+
+<details>
+  <summary>VariableDisplayTypeV2</summary>
+
+  | Value |
+|-------|
+| `VARIABLE_DISPLAY_TYPE_V2_UNSPECIFIED` |
+| `VARIABLE_DISPLAY_TYPE_V2_LABEL_VALUE` |
+| `VARIABLE_DISPLAY_TYPE_V2_VALUE` |
+| `VARIABLE_DISPLAY_TYPE_V2_NOTHING` |
+</details>
+
+For the full message structure and field-level documentation, see [`variable.proto`](https://github.com/coralogix/cx-management-apis/blob/master/proto/com/coralogixapis/dashboards/v1/ast/variables_v2/variable.proto) in the `cx-management-apis` repository.

--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -467,4 +467,4 @@ A `oneof` over six variants (proto names):
 | `VARIABLE_DISPLAY_TYPE_V2_NOTHING` |
 </details>
 
-For the full message structure and field-level documentation, see [`variable.proto`](https://github.com/coralogix/cx-management-apis/blob/master/proto/com/coralogixapis/dashboards/v1/ast/variables_v2/variable.proto) in the `cx-management-apis` repository.
+For the full message structure, see the `VariableV2`, `VariableSourceV2.*`, `VariableValueV2.*`, and `VariableDisplayTypeV2` schemas in `openapi_v5.yaml`.


### PR DESCRIPTION
Resolves [CX-42003](https://coralogix.atlassian.net/browse/CX-42003).

Independent of CX-42004 ([#81](https://github.com/coralogix/cx-api-docs/pull/81)) and CX-42005 ([#82](https://github.com/coralogix/cx-api-docs/pull/82)) — all three append a new section to `service-overviews/dashboard-service-overview.mdx` at the same anchor (file end). Trivial textual conflicts at merge time auto-resolve; no merge-order dependency.

Part of the dashboards/v1/ast gap surfaced by the `cx-api-docs` skill ([coralogix/documentation#2512](https://github.com/coralogix/documentation/pull/2512)).

## What changed

Adds a **Variables (V2)** section to `service-overviews/dashboard-service-overview.mdx` covering:

- Top-level `VariableV2` message (with `id`, `name`, `display_name`, `description`, `display_type`, `source`, `value`, `display_full_row`)
- Source variants: `QuerySource` / `StaticSource` / `TextboxSource` (Query has 4 data-source sub-variants)
- Value variants: `SingleStringValue` / `SingleNumericValue` / `MultiStringValue` / `LuceneQueryValue` / `RegexValue` / `IntervalValue`
- `VariableDisplayTypeV2` enum
- V1/V2 coexistence note

All schemas verified against `openapi_v5.yaml`.

## Out of scope

- Populating the openapi spec schema `description` / `title` fields for `VariableV2*` — requires upstream service-definition annotations. Filed in CX-42003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CX-42003]: https://coralogix.atlassian.net/browse/CX-42003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ