### PR TITLE
CX-42004: Document Dynamic widget in dashboard service overview

### DIFF
--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -439,7 +439,7 @@ A `Dynamic` message has the following fields:
 - **`time_frame`** — Optional override for the dashboard-level time frame.
 - **`interpretation`** — How the query result should be interpreted.
 - **`visualization`** — How the interpreted result should be rendered.
-- **`query`** — *Deprecated.* Single-query form, superseded by `query_definitions`. **The deprecation is marked in the proto (`[deprecated = true]`) but is not propagated to the generated openapi spec — treat the field as deprecated regardless of what the spec reports.** New integrations should populate `query_definitions` only.
+- **`query`** — *Deprecated.* Single-query form, superseded by `query_definitions`. **The field is deprecated in the upstream service definition but the deprecation does not propagate to the generated openapi spec — treat the field as deprecated regardless of what the spec reports.** New integrations should populate `query_definitions` only.
 
 ### Query variants (`Dynamic.Query`)
 
@@ -450,4 +450,4 @@ The `query` field (legacy) and each `QueryDefinition.query` are a `oneof` over f
 - **Metrics** — PromQL query (`PromQlQuery`).
 - **DataPrime** — DataPrime query.
 
-For the full message structure and field-level documentation, see [`dynamic.proto`](https://github.com/coralogix/cx-management-apis/blob/master/proto/com/coralogixapis/dashboards/v1/ast/widgets/dynamic.proto) in the `cx-management-apis` repository.
+For the full message structure, see the `Dynamic.Query`, `Dynamic.QueryDefinition`, and per-data-source `DynamicQuery*` schemas in `openapi_v5.yaml`.

--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -428,3 +428,26 @@ To use the Dashboard service API you need to [create a personal or team API key]
 | `AGGREGATION_TYPE_AVG` |
 | `AGGREGATION_TYPE_SUM` |
 </details>
+
+## Dynamic widget
+
+The Dynamic widget is a generic, query-driven widget that visualizes results from one or more queries against Coralogix data. Unlike the chart-specific widget types (`LineChart`, `BarChart`, `PieChart`, `Gauge`, etc.), the Dynamic widget accepts a query payload plus an interpretation and visualization configuration, letting the dashboard render the result with the renderer that fits the data shape.
+
+A `Dynamic` message has the following fields:
+
+- **`query_definitions`** *(repeated)* — One or more `QueryDefinition` entries, each with an `id`, a `query`, and an optional `name`. Use this for multi-query widgets (overlays, comparisons).
+- **`time_frame`** — Optional override for the dashboard-level time frame.
+- **`interpretation`** — How the query result should be interpreted.
+- **`visualization`** — How the interpreted result should be rendered.
+- **`query`** — *Deprecated.* Single-query form, superseded by `query_definitions`. **The deprecation is marked in the proto (`[deprecated = true]`) but is not propagated to the generated openapi spec — treat the field as deprecated regardless of what the spec reports.** New integrations should populate `query_definitions` only.
+
+### Query variants (`Dynamic.Query`)
+
+The `query` field (legacy) and each `QueryDefinition.query` are a `oneof` over four data sources:
+
+- **Logs** — Lucene query (`LuceneQuery`).
+- **Spans** — Lucene query.
+- **Metrics** — PromQL query (`PromQlQuery`).
+- **DataPrime** — DataPrime query.
+
+For the full message structure and field-level documentation, see [`dynamic.proto`](https://github.com/coralogix/cx-management-apis/blob/master/proto/com/coralogixapis/dashboards/v1/ast/widgets/dynamic.proto) in the `cx-management-apis` repository.


### PR DESCRIPTION
Resolves [CX-42004](https://coralogix.atlassian.net/browse/CX-42004).

Independent of CX-42003 ([#80](https://github.com/coralogix/cx-api-docs/pull/80)) and CX-42005 ([#82](https://github.com/coralogix/cx-api-docs/pull/82)) — all three append a new section to `service-overviews/dashboard-service-overview.mdx` at the same anchor (file end). Trivial textual conflicts at merge time auto-resolve; no merge-order dependency.

Part of the dashboards/v1/ast gap surfaced by the `cx-api-docs` skill ([coralogix/documentation#2512](https://github.com/coralogix/documentation/pull/2512)).

## What changed

Adds a **Dynamic widget** section to `service-overviews/dashboard-service-overview.mdx` covering:

- Top-level `Dynamic` message (`query_definitions`, `time_frame`, `interpretation`, `visualization`)
- **Deprecation callout for `Dynamic.query`** — deprecated in the upstream service definition but the deprecation does NOT propagate to the openapi spec. Doc surfaces the deprecation explicitly with migration guidance to `query_definitions`.
- Query variants: Logs (Lucene), Spans (Lucene), Metrics (PromQL), DataPrime

All schemas verified against `openapi_v5.yaml`.

## Out of scope

- Populating openapi spec schema descriptions for `Dynamic.*`.
- Fixing the openapi generator so it propagates field-level deprecation.

Both filed in CX-42004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CX-42004]: https://coralogix.atlassian.net/browse/CX-42004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ