### PR TITLE
CX-42005: Document Annotations in dashboard service overview

### DIFF
--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -447,21 +447,21 @@ An `Annotation` message has:
 
 A `oneof` over six source types:
 
-- **`MetricsSource`** — events from a PromQL query. Carries a `Strategy` (currently `StartTimeMetric` — uses the first data point's value as the annotation timestamp), a `message_template`, label list, `AnnotationOrientation`, and an `IntervalResolution`.
-- **`LogsSource`** — events from a Lucene logs query. The strategy is a `oneof` over `Instant` (single timestamp field), `Range` (start + end timestamp fields), and `Duration` (start timestamp + duration field). Supports `label_fields` and `DataModeType`.
+- **`MetricsSource`** — events from a PromQL query (`promql_query`). Carries a `Strategy` (currently `StartTimeMetric` — uses the first data point's value as the annotation timestamp), a `message_template`, label list, `AnnotationOrientation`, and an `IntervalResolution`.
+- **`LogsSource`** — events from a Lucene logs query (`lucene_query`). The strategy is a `oneof` over `Instant` (single timestamp field), `Range` (start + end timestamp fields), and `Duration` (start timestamp + duration field). Supports `label_fields` and `DataModeType`.
 - **`SpansSource`** — same shape as `LogsSource` but over spans.
-- **`DataprimeSource`** — events from a DataPrime query with the same Instant/Range/Duration strategy variants.
-- **`ManualSource`** — events entered by hand in the dashboard UI.
-- **`EventRecurrenceSource`** — events from a recurring schedule.
+- **`DataprimeSource`** — events from a DataPrime query (`query`) with the same Instant/Range/Duration strategy variants.
+- **`ManualSource`** — manually configured events with an `Instant` (single `value` + `Unit`) or `Range` (`start_value` / `end_value` + `Unit`) strategy. Optional `custom_unit`, `message_template`, and `AnnotationOrientation`.
+- **`EventRecurrenceSource`** — events from a recurring schedule. Currently only `WeeklyRecurrence` (with selectable `days_of_week` from a `Weekday` enum) is supported, paired with an `Instant` (start hour) or `Duration` (start hour + length) strategy.
 
-### Scope (`Annotation.WidgetScope`) — v5 only
+### Scope — `Annotation.WidgetScope` (v5 only)
 
-In `openapi_v5.yaml`, `WidgetScope` is a `oneof` over:
+`Annotation.WidgetScope` is a `oneof` over:
 
 - **`AllWidgets`** — annotation overlays every widget on the dashboard.
-- **`SpecificWidgets`** — annotation overlays only the listed widget IDs.
+- **`SpecificWidgets`** — annotation overlays only the listed `widget_ids`.
 
-Earlier spec versions (`v3`, `v4`) do not include `WidgetScope`; the annotation surface there is the 15-schema subset without per-widget targeting.
+Earlier spec versions (`v3`, `v4`) do not scope annotations to specific widgets — that surface is v5-only. (A separate top-level `WidgetScope` family exists in `v3` and `v4` for `Filter` scoping; it's unrelated to annotations.)
 
 ### Events (`AnnotationEvent`)
 

--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -477,6 +477,6 @@ When the dashboard renders an annotation, each emitted event is either:
 
 ### Widget-side: filtering an annotation's series
 
-`AnnotationSeriesVisibility` is **not** part of the `Annotation` message — it lives under `widgets/common/series_visibility.proto`. It's an entry inside a widget's `SeriesVisibility.annotation_series` list, with `annotation_id`, a `SeriesVisibilityMode` (`HIDE_ALL` / `SHOW_ONLY`), and a `series_names` list. Use it on the widget side to control which series of an already-defined annotation render on that widget.
+`AnnotationSeriesVisibility` is **not** part of the `Annotation` message — it's defined alongside the widget-level `SeriesVisibility` schema. It's an entry inside a widget's `SeriesVisibility.annotation_series` list, with `annotation_id`, a `SeriesVisibilityMode` (`HIDE_ALL` / `SHOW_ONLY`), and a `series_names` list. Use it on the widget side to control which series of an already-defined annotation render on that widget.
 
-For the full message structure and field-level documentation, see [`annotation.proto`](https://github.com/coralogix/cx-management-apis/blob/master/proto/com/coralogixapis/dashboards/v1/ast/annotations/annotation.proto) in the `cx-management-apis` repository.
+For the full message structure, see the `Annotation` and `Annotation.Source.*` schema families in `openapi_v5.yaml`.

--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -428,3 +428,52 @@ To use the Dashboard service API you need to [create a personal or team API key]
 | `AGGREGATION_TYPE_AVG` |
 | `AGGREGATION_TYPE_SUM` |
 </details>
+
+## Annotations
+
+Annotations mark significant events on dashboard widgets — for example, deploys, incidents, or business milestones — so they appear as overlays on charts that match their scope. An annotation is sourced from a Coralogix query, manual input, or a recurring event, and can be scoped to all widgets on the dashboard or a specific set.
+
+An `Annotation` message has:
+
+- `id` — unique identifier
+- `name` — display name
+- `description` — optional description
+- `enabled` — boolean toggle
+- `source` — where the events come from (see below)
+- `scope` — which widgets the annotation overlays
+- `color` — an `AnnotationColor` enum value
+
+### Source (`Annotation.Source`)
+
+A `oneof` over six source types:
+
+- **`MetricsSource`** — events from a PromQL query. Carries a `Strategy` (currently `StartTimeMetric` — uses the first data point's value as the annotation timestamp), a `message_template`, label list, `AnnotationOrientation`, and an `IntervalResolution`.
+- **`LogsSource`** — events from a Lucene logs query. The strategy is a `oneof` over `Instant` (single timestamp field), `Range` (start + end timestamp fields), and `Duration` (start timestamp + duration field). Supports `label_fields` and `DataModeType`.
+- **`SpansSource`** — same shape as `LogsSource` but over spans.
+- **`DataprimeSource`** — events from a DataPrime query with the same Instant/Range/Duration strategy variants.
+- **`ManualSource`** — events entered by hand in the dashboard UI.
+- **`EventRecurrenceSource`** — events from a recurring schedule.
+
+### Scope (`Annotation.WidgetScope`) — v5 only
+
+In `openapi_v5.yaml`, `WidgetScope` is a `oneof` over:
+
+- **`AllWidgets`** — annotation overlays every widget on the dashboard.
+- **`SpecificWidgets`** — annotation overlays only the listed widget IDs.
+
+Earlier spec versions (`v3`, `v4`) do not include `WidgetScope`; the annotation surface there is the 15-schema subset without per-widget targeting.
+
+### Events (`AnnotationEvent`)
+
+When the dashboard renders an annotation, each emitted event is either:
+
+- **`Instant`** — a point in time with `timestamp`, `labels`, and `payload`.
+- **`Range`** — a span with `start`, `end`, `labels`, and `payload`.
+
+### Related types
+
+- `AnnotationColor` *(enum)* — color the annotation renders with.
+- `AnnotationOrientation` *(enum)* — vertical / horizontal placement for metrics-sourced annotations.
+- `AnnotationSeriesVisibility` — widget-level configuration controlling which series in an annotation are visible.
+
+For the full message structure and field-level documentation, see [`annotation.proto`](https://github.com/coralogix/cx-management-apis/blob/master/proto/com/coralogixapis/dashboards/v1/ast/annotations/annotation.proto) in the `cx-management-apis` repository.

--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -474,6 +474,9 @@ When the dashboard renders an annotation, each emitted event is either:
 
 - `AnnotationColor` *(enum)* — color the annotation renders with.
 - `AnnotationOrientation` *(enum)* — vertical / horizontal placement for metrics-sourced annotations.
-- `AnnotationSeriesVisibility` — widget-level configuration controlling which series in an annotation are visible.
+
+### Widget-side: filtering an annotation's series
+
+`AnnotationSeriesVisibility` is **not** part of the `Annotation` message — it lives under `widgets/common/series_visibility.proto`. It's an entry inside a widget's `SeriesVisibility.annotation_series` list, with `annotation_id`, a `SeriesVisibilityMode` (`HIDE_ALL` / `SHOW_ONLY`), and a `series_names` list. Use it on the widget side to control which series of an already-defined annotation render on that widget.
 
 For the full message structure and field-level documentation, see [`annotation.proto`](https://github.com/coralogix/cx-management-apis/blob/master/proto/com/coralogixapis/dashboards/v1/ast/annotations/annotation.proto) in the `cx-management-apis` repository.


### PR DESCRIPTION
Resolves [CX-42005](https://coralogix.atlassian.net/browse/CX-42005).

Independent of CX-42003 ([#80](https://github.com/coralogix/cx-api-docs/pull/80)) and CX-42004 ([#81](https://github.com/coralogix/cx-api-docs/pull/81)) — all three append a new section to `service-overviews/dashboard-service-overview.mdx` at the same anchor (file end). Trivial textual conflicts at merge time auto-resolve; no merge-order dependency.

Part of the dashboards/v1/ast gap surfaced by the `cx-api-docs` skill ([coralogix/documentation#2512](https://github.com/coralogix/documentation/pull/2512)).

## What changed

Adds an **Annotations** section to `service-overviews/dashboard-service-overview.mdx` covering:

- Top-level `Annotation` message (`id`, `name`, `description`, `enabled`, `source`, `scope`, `color`)
- Source: 6 variants (Metrics with `StartTimeMetric` strategy; Logs/Spans/DataPrime each with Instant/Range/Duration strategies; Manual with structured Instant/Range value strategies; EventRecurrence with WeeklyRecurrence + Instant/Duration)
- **`Annotation.WidgetScope`** — v5-only surface with `AllWidgets` vs `SpecificWidgets`. (Note: a separate top-level `WidgetScope` for `Filter` scoping exists in v3/v4 and is unrelated.)
- `AnnotationEvent` Instant vs Range
- Related types: `AnnotationColor`, `AnnotationOrientation`
- Widget-side `AnnotationSeriesVisibility` (defined alongside widget-level `SeriesVisibility`, not part of the Annotation family)

All schemas verified against `openapi_v5.yaml`.

## Out of scope

- Populating openapi spec schema descriptions for `Annotation.*`. Filed in CX-42005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CX-42005]: https://coralogix.atlassian.net/browse/CX-42005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ