### PR TITLE
CX-42196: Expand dashboard service overview — widget catalog (PR B)

### DIFF
--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -19,6 +19,110 @@ To use the Dashboard service API you need to [create a personal or team API key]
 | `401 Unauthorized` | Response code 401 |
 | `500 Internal Server Error` | Response code 500 |
 
+## Widget catalog
+
+Each widget type below corresponds to one variant of the `Widget.Definition` `oneof`. Every chart widget accepts a query over one of four data sources — Logs (Lucene), Spans (Lucene), Metrics (PromQL), or DataPrime — and renders the result with a type-specific visualization. The `Markdown` widget is the exception: it carries no query and just renders user-supplied markdown text.
+
+### LineChart
+
+Renders one or more queries as line series over time. Supports multi-query overlays through `query_definitions` (repeated) — each definition has an `id`, a `query`, and an optional `name`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `query_definitions` | `[QueryDefinition]` | **Required.** One or more line series. Each definition's `query` is a `oneof` over Logs / Spans / Metrics / DataPrime. |
+| `legend` | `Legend` | Legend placement and content options. |
+| `tooltip` | `Tooltip` | Hover-tooltip behavior. |
+| `stacked_line` | `StackedLine` enum | One of `UNSPECIFIED`, `ABSOLUTE`, `RELATIVE`. Controls whether series stack and how. |
+| `connect_nulls` | `boolean` | Whether to bridge gaps in data instead of producing scattered points when null values appear. |
+| `x_axis_time_format` | `XAxisTimeFormat` | Optional override of the X axis time format. |
+
+See the `LineChart` and `LineChart.QueryDefinition` schemas in `openapi_v5.yaml` for the per-query-source field list.
+
+### BarChart
+
+Vertical bar chart. Single-query (does not use `query_definitions`).
+
+| Field | Type | Notes |
+|---|---|---|
+| `query` | `Query` | A `oneof` over Logs / Spans / Metrics / DataPrime. |
+| `max_bars_per_chart` | `int32` | Cap on bar count. |
+| `group_name_template` | `string` | Custom display name for grouped bars; supports `{{ variable }}` substitution. |
+| `stack_definition` | `StackDefinition` | If set, bars stack; controls per-stack appearance. |
+| `scale_type` | `ScaleType` | `LINEAR` or `LOGARITHMIC`. |
+| `colors_by` | `ColorsBy` | How bar colors are assigned (by group, by stack, etc.). |
+| `unit` | `Unit` | One from the `Unit` enum or `CUSTOM`. |
+
+### HorizontalBarChart
+
+Bar chart with horizontal bars. Same payload shape as `BarChart`: single `query`, `max_bars_per_chart`, `group_name_template`, `stack_definition`, `scale_type`, `colors_by`, `unit`. Use when the category axis is long enough that horizontal layout is more readable.
+
+### PieChart
+
+Pie / donut chart. Single-query.
+
+| Field | Type | Notes |
+|---|---|---|
+| `query` | `Query` | A `oneof` over Logs / Spans / Metrics / DataPrime. |
+| `max_slices_per_chart` | `int32` | Cap on slice count. |
+| `min_slice_percentage` | `int32` | Slices below this percentage are folded into an "other" group. |
+| `stack_definition` | `StackDefinition` | If set, produces a stacked / donut layout. |
+| `label_definition` | `LabelDefinition` | Slice label rendering options. |
+| `group_name_template` | `string` | Slice-group naming; supports `{{ variable }}` substitution. |
+| `unit` | `Unit` | One from the `Unit` enum or `CUSTOM`. |
+| `show_legend` | `boolean` | *Marked "to be deprecated" in the proto.* Legend visibility is migrating to `Legend.is_visible`. |
+
+### Gauge
+
+Single-value gauge. Shows one number against a min/max range with optional thresholds.
+
+| Field | Type | Notes |
+|---|---|---|
+| `query` | `Query` | Single-query (returns one numeric value). |
+| `min`, `max` | `double` | Range used both for the visual arc and for percentage-threshold calculation. |
+| `show_inner_arc` | `boolean` | Whether the inner arc (which graphically represents the value) renders. |
+| `show_outer_arc` | `boolean` | Whether the outer arc (which represents the min/max range) renders. |
+| `unit` | `Unit` | One from the `Unit` enum or `CUSTOM`. |
+| `thresholds` | `[Threshold]` | Color bands keyed off the value, each with an optional name label. |
+
+### Hexagon
+
+Single-value display rendered as a hexagonal cell, typically used in a grid of hexagons in a dashboard section. Shape is similar to `Gauge` but without the arc visualization.
+
+| Field | Type | Notes |
+|---|---|---|
+| `query` | `Query` | Single-query. |
+| `min`, `max` | `double` | Range used for percentage-threshold calculation. |
+| `unit` | `Unit` | One from the `Unit` enum or `CUSTOM`. |
+| `thresholds` | `[Threshold]` | Color bands; each can carry a name label. |
+
+### DataTable
+
+Tabular renderer. Returns one row per result item, with developer-defined columns.
+
+| Field | Type | Notes |
+|---|---|---|
+| `query` | `Query` | A `oneof` over Logs / Spans / Metrics / DataPrime. |
+| `results_per_page` | `int32` | Page size. |
+| `row_style` | `RowStyle` | One of `ONE_LINE`, `TWO_LINE`, `CONDENSED`, `JSON`, `LIST` (see the Constants section). |
+| `columns` | `[Column]` | Ordered list of column definitions (field reference, width, formatting). |
+| `order_by` | `OrderingField` | Server-side ordering of the result set. |
+| `data_mode_type` | `DataModeType` | `HIGH` or `ARCHIVE`. |
+
+### Markdown
+
+Static prose widget. Does not run a query.
+
+| Field | Type | Notes |
+|---|---|---|
+| `markdown_text` | `string` | The body content; standard Markdown syntax. |
+| `tooltip_text` | `string` | Tooltip shown on widget hover. |
+
+Use the Markdown widget for runbook links, dashboard headers, contextual notes, or anywhere a fixed text panel needs to live in the grid.
+
+### Dynamic
+
+Generic query-driven widget — different from the chart widgets above in that it accepts query results in a shape-agnostic form and lets the dashboard renderer choose the visualization. See the Dynamic widget section.
+
 ## Constants
 
 <details>

--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -23,6 +23,8 @@ To use the Dashboard service API you need to [create a personal or team API key]
 
 Each widget type below corresponds to one variant of the `Widget.Definition` `oneof`. Every chart widget accepts a query over one of four data sources — Logs (Lucene), Spans (Lucene), Metrics (PromQL), or DataPrime — and renders the result with a type-specific visualization. The `Markdown` widget is the exception: it carries no query and just renders user-supplied markdown text.
 
+Each section below lists the **key fields** most relevant to constructing a widget payload. For the full field set per widget (color schemes, legend configuration, decimal precision, axis bounds, custom units, etc.), see the corresponding schema in `openapi_v5.yaml`.
+
 ### LineChart
 
 Renders one or more queries as line series over time. Supports multi-query overlays through `query_definitions` (repeated) — each definition has an `id`, a `query`, and an optional `name`.
@@ -54,7 +56,7 @@ Vertical bar chart. Single-query (does not use `query_definitions`).
 
 ### HorizontalBarChart
 
-Bar chart with horizontal bars. Same payload shape as `BarChart`: single `query`, `max_bars_per_chart`, `group_name_template`, `stack_definition`, `scale_type`, `colors_by`, `unit`. Use when the category axis is long enough that horizontal layout is more readable.
+Bar chart with horizontal bars. Mostly mirrors `BarChart` (single `query`, `max_bars_per_chart`, `group_name_template`, `stack_definition`, `scale_type`, `colors_by`, `unit`) but the axis-handling controls differ: `HorizontalBarChart` uses `y_axis_view_by` (category vs value bucketing) and `display_on_bar` (bar-label placement) where `BarChart` uses `x_axis` and `bar_value_display`. Use the horizontal layout when the category axis is long enough that vertical labels would overflow.
 
 ### PieChart
 
@@ -69,7 +71,7 @@ Pie / donut chart. Single-query.
 | `label_definition` | `LabelDefinition` | Slice label rendering options. |
 | `group_name_template` | `string` | Slice-group naming; supports `{{ variable }}` substitution. |
 | `unit` | `Unit` | One from the `Unit` enum or `CUSTOM`. |
-| `show_legend` | `boolean` | *Marked "to be deprecated" in the proto.* Legend visibility is migrating to `Legend.is_visible`. |
+| `show_legend` | `boolean` | The upstream service definition describes this field as "not used, to be deprecated." |
 
 ### Gauge
 


### PR DESCRIPTION
Resolves [CX-42196](https://coralogix.atlassian.net/browse/CX-42196) — PR B of 2.

Sibling to [#83 — PR A (structural)](https://github.com/coralogix/cx-api-docs/pull/83). Branches independently from \`main\`; either can merge first.

## What changed

Adds one section per chart widget type to \`service-overviews/dashboard-service-overview.mdx\`, inserted before the existing \`## Constants\` block:

| Widget | Single/multi query | Key fields |
|---|---|---|
| LineChart | **multi** (\`query_definitions\`) | legend, tooltip, stacked_line, connect_nulls, x_axis_time_format |
| BarChart | single | max_bars_per_chart, group_name_template, stack_definition, scale_type, colors_by, unit |
| HorizontalBarChart | single | (same shape as BarChart) |
| PieChart | single | max_slices, min_slice_percentage, stack_definition, label_definition, group_name_template, unit (+ deprecated show_legend) |
| Gauge | single | min/max, show_inner_arc, show_outer_arc, unit, thresholds |
| Hexagon | single | min/max, unit, thresholds |
| DataTable | single | results_per_page, row_style, columns, order_by, data_mode_type |
| Markdown | none | markdown_text, tooltip_text |
| Dynamic | (cross-reference to [#81](https://github.com/coralogix/cx-api-docs/pull/81)) | |

All fields and enum names sourced from the proto definitions and verified against \`openapi_v5.yaml\` schema names.

## How this composes with sibling PRs

All four "expansion" PRs insert content before the existing \`Constants\` block of \`dashboard-service-overview.mdx\`. They're independently mergeable:

- [#80 CX-42003](https://github.com/coralogix/cx-api-docs/pull/80) — Variables V2
- [#81 CX-42004](https://github.com/coralogix/cx-api-docs/pull/81) — Dynamic widget
- [#82 CX-42005](https://github.com/coralogix/cx-api-docs/pull/82) — Annotations
- [#83 CX-42196 PR A](https://github.com/coralogix/cx-api-docs/pull/83) — structural (Endpoints + Dashboard payload + Layout + Widgets overview + Variables V1 + Filters + Time frame + Actions + folders expansion)
- **This PR (CX-42196 PR B)** — widget catalog

Some textual conflicts may arise at merge time (all PRs append in the same region) — trivial to auto-resolve.

## Out of scope

- Operation-level descriptions for 12 endpoints (backend proto work, diagnostic §7 action #1)
- Path-parameter descriptions (backend proto work, diagnostic §7 action #2)
- Render \`x-coralogixPermissions\` in Mintlify (Mintlify config, diagnostic §7 action #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-42196]: https://coralogix.atlassian.net/browse/CX-42196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ