### PR TITLE
[CX-43078] Document dashboard access-policy permissions and field semantics

### DIFF
--- a/api-reference/v5/dashboard-service/overview.mdx
+++ b/api-reference/v5/dashboard-service/overview.mdx
@@ -10,6 +10,32 @@ To use the Dashboard service API you need to [create a personal or team API key]
 |---------|-----------------------|--------------------------------------------------|
 | Dashboards | `team-dashboards:Read` | Grants access to read team-dashboards |
 |  | `team-dashboards:Update` | Required to create, update, or delete team-dashboards |
+|  | `team-dashboards:ReadAccessPolicy` | Required to read a dashboard's access policy |
+|  | `team-dashboards:UpdateAccessPolicy` | Required to set or remove a dashboard's access policy |
+
+## Dashboard access policy
+
+Dashboards support [policy-based access control](https://coralogix.com/docs/user-guides/aaa/access-control/policies/) (PBAC). The optional `access_policy` field on the dashboard CRUD endpoints reads and writes the policy as a JSON string:
+
+- **Create dashboard** and **Replace dashboard**: a non-empty `access_policy` string sets the policy, an empty string removes it, and omitting the field leaves the existing policy unchanged. Setting or removing a policy requires `team-dashboards:UpdateAccessPolicy`.
+- **Get dashboard** and **Get dashboard by slug**: the response returns the current policy in `access_policy`. The field is omitted if you lack `team-dashboards:ReadAccessPolicy`, and is an empty string if no policy is set.
+
+### Example dashboard access policy
+
+```
+{
+  "version": "2025-01-01",
+  "rules": [],
+  "default": {
+    "permissions": {
+      "team-dashboards:Read": "grant",
+      "team-dashboards:Update": "deny",
+      "team-dashboards:ReadAccessPolicy": "grant",
+      "team-dashboards:UpdateAccessPolicy": "deny"
+    }
+  }
+}
+```
 
 ## Common error response codes
 

--- a/service-overviews/dashboard-service-overview.mdx
+++ b/service-overviews/dashboard-service-overview.mdx
@@ -10,6 +10,32 @@ To use the Dashboard service API you need to [create a personal or team API key]
 |---------|-----------------------|--------------------------------------------------|
 | Dashboards | `team-dashboards:Read` | Grants access to read team-dashboards |
 |  | `team-dashboards:Update` | Required to create, update, or delete team-dashboards |
+|  | `team-dashboards:ReadAccessPolicy` | Required to read a dashboard's access policy |
+|  | `team-dashboards:UpdateAccessPolicy` | Required to set or remove a dashboard's access policy |
+
+## Dashboard access policy
+
+Dashboards support [policy-based access control](https://coralogix.com/docs/user-guides/aaa/access-control/policies/) (PBAC). The optional `access_policy` field on the dashboard CRUD endpoints reads and writes the policy as a JSON string:
+
+- **Create dashboard** and **Replace dashboard**: a non-empty `access_policy` string sets the policy, an empty string removes it, and omitting the field leaves the existing policy unchanged. Setting or removing a policy requires `team-dashboards:UpdateAccessPolicy`.
+- **Get dashboard** and **Get dashboard by slug**: the response returns the current policy in `access_policy`. The field is omitted if you lack `team-dashboards:ReadAccessPolicy`, and is an empty string if no policy is set.
+
+### Example dashboard access policy
+
+```
+{
+  "version": "2025-01-01",
+  "rules": [],
+  "default": {
+    "permissions": {
+      "team-dashboards:Read": "grant",
+      "team-dashboards:Update": "deny",
+      "team-dashboards:ReadAccessPolicy": "grant",
+      "team-dashboards:UpdateAccessPolicy": "deny"
+    }
+  }
+}
+```
 
 ## Common error response codes
 


### PR DESCRIPTION
## Summary

[cx-management-apis#224](https://github.com/coralogix/cx-management-apis/pull/224) ([CX-43078](https://coralogix.atlassian.net/browse/CX-43078)) added an optional `access_policy` field (opaque PBAC policy JSON string) to `CreateDashboardRequest`, `ReplaceDashboardRequest`, `GetDashboardResponse`, and `GetDashboardBySlugResponse`.

This updates the Dashboard service overview to match, mirroring the API keys service overview pattern (#71):

- Add `team-dashboards:ReadAccessPolicy` / `team-dashboards:UpdateAccessPolicy` to the permissions table.
- Add a **Dashboard access policy** section documenting the field semantics (non-empty sets, empty string removes, omitted leaves unchanged; Get responses omit the field without read permission) and an example policy taken from the proto field example.
- Updated `service-overviews/dashboard-service-overview.mdx` and the published `api-reference/v5` copy only — v3/v4 specs are frozen snapshots that won't expose the field (the sync workflow targets `openapi_v5.yaml` only).

Companion PR in the docs portal: coralogix/documentation#2761.

## ⚠️ Hold merge

As of 2026-06-02, the staging openapi-facade spec does **not** yet expose `access_policy` on the dashboard endpoints — `CreateDashboardRequest` still shows only `dashboard`/`isLocked`/`requestId`. The generated v5 reference will only pick up the field after the next `facade-spec-updated` sync. Merge once the facade spec includes the field (or the dashboards team confirms rollout), ideally together with a spec re-sync so the overview and the generated reference land consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-43078]: https://coralogix.atlassian.net/browse/CX-43078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ