### PR TITLE
docs(ai): add AI Applications and AI Evaluations service overviews

### DIFF
--- a/api-reference/v5/ai-applications-service/overview.mdx
+++ b/api-reference/v5/ai-applications-service/overview.mdx
@@ -1,0 +1,23 @@
+# AI Applications service overview
+
+The AI Applications service manages the catalog of AI applications that Coralogix automatically discovers from your spans. Use it to list the AI applications in your account (optionally filtered by evaluation type), retrieve a single application by its ID, and delete an application from the catalog. The service also manages your company-wide custom model pricing, letting you read, replace, or delete the per-model pricing Coralogix uses when it calculates the cost of AI application activity.
+
+Learn more in our [documentation](https://coralogix.com/docs/user-guides/ai/app_catalog/).
+
+## Authentication and permissions
+
+To use the AI Applications service API you need to [create a personal or team API key](https://coralogix.com/docs/user-guides/account-management/api-keys/api-keys/). The permissions below are part of the **AiObservability** role preset; assign that preset, or add the individual permissions you need.
+
+| Presets | Permission | Description |
+|---------|-----------|-------------|
+| AiObservability | `AI-APP-CATALOG:READ` | View the Application Catalog. |
+| AiObservability | `AI-APP-DISCOVERY:READ` | View AI App Discovery. |
+| AiObservability | `AI-APP-DISCOVERY:MANAGE` | Activate AI App Discovery and rescan to detect new AI apps. |
+
+## Common error response codes
+
+| Status Code | Description                           |
+|-------------|---------------------------------------|
+| `400 Bad Request` | Response code 400 |
+| `401 Unauthorized` | Response code 401 |
+| `500 Internal Server Error` | Response code 500 |

--- a/api-reference/v5/ai-evaluations-service/overview.mdx
+++ b/api-reference/v5/ai-evaluations-service/overview.mdx
@@ -1,0 +1,50 @@
+# AI Evaluations service overview
+
+The AI Evaluations service manages AI evaluations and the custom evaluation catalog for your AI applications. Use it to define, list, update, and delete custom evaluations in the catalog, and to link or unlink those custom evaluations to specific AI applications. The service also manages the evaluations that run against an application: list them (optionally filtered by application, subsystem, or evaluation type), create, retrieve, update, and delete an evaluation, and count how many AI applications use each evaluation type.
+
+Learn more in our [documentation](https://coralogix.com/docs/user-guides/ai/evaluations/).
+
+## Authentication and permissions
+
+To use the AI Evaluations service API you need to [create a personal or team API key](https://coralogix.com/docs/user-guides/account-management/api-keys/api-keys/). The permissions below are part of the **AiObservability** role preset; assign that preset, or add the individual permissions you need.
+
+| Presets | Permission | Description |
+|---------|-----------|-------------|
+| AiObservability | `AI-APP-EVALUATORS:READ` | View the Application Eval Catalog. |
+| AiObservability | `AI-APP-EVALUATORS:MANAGE` | Add, edit, and delete evals for an application. |
+
+## Common error response codes
+
+| Status Code | Description                           |
+|-------------|---------------------------------------|
+| `400 Bad Request` | Response code 400 |
+| `401 Unauthorized` | Response code 401 |
+| `500 Internal Server Error` | Response code 500 |
+
+## Constants
+
+<details>
+  <summary>EvaluationType</summary>
+
+  | Value |
+|-------|
+| `ALLOWED_TOPICS` |
+| `COMPETITION` |
+| `HALLUCINATION_COMPLETENESS` |
+| `HALLUCINATION_CONTEXT_ADHERENCE` |
+| `HALLUCINATION_CONTEXT_RELEVANCE` |
+| `HALLUCINATION_CORRECTNESS` |
+| `HALLUCINATION_TASK_ADHERENCE` |
+| `PII` |
+| `PROMPT_INJECTION` |
+| `RESTRICTED_TOPICS` |
+| `SEXISM` |
+| `SQL_ALLOWED_TABLES` |
+| `SQL_HALLUCINATION` |
+| `SQL_LOAD` |
+| `SQL_READ_ONLY` |
+| `SQL_RESTRICTED_TABLES` |
+| `TOXICITY` |
+| `LANGUAGE_MISMATCH` |
+| `CUSTOM_EVALUATION` |
+</details>

--- a/build_navigation_file.py
+++ b/build_navigation_file.py
@@ -63,6 +63,8 @@ V4_SERVICES = {
 
 V5_SERVICES = {
     **V4_SERVICES,
+    'ai-applications-service': 'AI Applications Service',
+    'ai-evaluations-service': 'AI Evaluations Service',
     'connector-schema-service': 'Connector Schema Service',
     'notifications-testing-service': 'Notifications Testing Service',
     'cases-service': 'Cases Service',

--- a/docs.json
+++ b/docs.json
@@ -33,6 +33,37 @@
             ]
           },
           {
+            "group": "AI Applications Service",
+            "pages": [
+              "api-reference/v5/ai-applications-service/overview",
+              "api-reference/v5/ai-applications-service/delete-ai-application",
+              "api-reference/v5/ai-applications-service/delete-company-model-pricing",
+              "api-reference/v5/ai-applications-service/get-ai-application",
+              "api-reference/v5/ai-applications-service/get-company-model-pricing",
+              "api-reference/v5/ai-applications-service/list-ai-applications",
+              "api-reference/v5/ai-applications-service/set-company-model-pricing"
+            ]
+          },
+          {
+            "group": "AI Evaluations Service",
+            "pages": [
+              "api-reference/v5/ai-evaluations-service/overview",
+              "api-reference/v5/ai-evaluations-service/count-applications-per-evaluation-type",
+              "api-reference/v5/ai-evaluations-service/create-ai-evaluation",
+              "api-reference/v5/ai-evaluations-service/create-custom-evaluation",
+              "api-reference/v5/ai-evaluations-service/delete-ai-evaluation",
+              "api-reference/v5/ai-evaluations-service/delete-custom-evaluation",
+              "api-reference/v5/ai-evaluations-service/get-ai-evaluation",
+              "api-reference/v5/ai-evaluations-service/link-custom-evaluation-to-application",
+              "api-reference/v5/ai-evaluations-service/list-ai-evaluations",
+              "api-reference/v5/ai-evaluations-service/list-custom-evaluations",
+              "api-reference/v5/ai-evaluations-service/list-custom-evaluations-for-application",
+              "api-reference/v5/ai-evaluations-service/unlink-custom-evaluation-from-application",
+              "api-reference/v5/ai-evaluations-service/update-ai-evaluation",
+              "api-reference/v5/ai-evaluations-service/update-custom-evaluation"
+            ]
+          },
+          {
             "group": "Alert Definitions Service",
             "pages": [
               "api-reference/v5/alert-definitions-service/overview",

--- a/service-overviews/ai-applications-service-overview.mdx
+++ b/service-overviews/ai-applications-service-overview.mdx
@@ -1,0 +1,23 @@
+# AI Applications service overview
+
+The AI Applications service manages the catalog of AI applications that Coralogix automatically discovers from your spans. Use it to list the AI applications in your account (optionally filtered by evaluation type), retrieve a single application by its ID, and delete an application from the catalog. The service also manages your company-wide custom model pricing, letting you read, replace, or delete the per-model pricing Coralogix uses when it calculates the cost of AI application activity.
+
+Learn more in our [documentation](https://coralogix.com/docs/user-guides/ai/app_catalog/).
+
+## Authentication and permissions
+
+To use the AI Applications service API you need to [create a personal or team API key](https://coralogix.com/docs/user-guides/account-management/api-keys/api-keys/). The permissions below are part of the **AiObservability** role preset; assign that preset, or add the individual permissions you need.
+
+| Presets | Permission | Description |
+|---------|-----------|-------------|
+| AiObservability | `AI-APP-CATALOG:READ` | View the Application Catalog. |
+| AiObservability | `AI-APP-DISCOVERY:READ` | View AI App Discovery. |
+| AiObservability | `AI-APP-DISCOVERY:MANAGE` | Activate AI App Discovery and rescan to detect new AI apps. |
+
+## Common error response codes
+
+| Status Code | Description                           |
+|-------------|---------------------------------------|
+| `400 Bad Request` | Response code 400 |
+| `401 Unauthorized` | Response code 401 |
+| `500 Internal Server Error` | Response code 500 |

--- a/service-overviews/ai-evaluations-service-overview.mdx
+++ b/service-overviews/ai-evaluations-service-overview.mdx
@@ -1,0 +1,50 @@
+# AI Evaluations service overview
+
+The AI Evaluations service manages AI evaluations and the custom evaluation catalog for your AI applications. Use it to define, list, update, and delete custom evaluations in the catalog, and to link or unlink those custom evaluations to specific AI applications. The service also manages the evaluations that run against an application: list them (optionally filtered by application, subsystem, or evaluation type), create, retrieve, update, and delete an evaluation, and count how many AI applications use each evaluation type.
+
+Learn more in our [documentation](https://coralogix.com/docs/user-guides/ai/evaluations/).
+
+## Authentication and permissions
+
+To use the AI Evaluations service API you need to [create a personal or team API key](https://coralogix.com/docs/user-guides/account-management/api-keys/api-keys/). The permissions below are part of the **AiObservability** role preset; assign that preset, or add the individual permissions you need.
+
+| Presets | Permission | Description |
+|---------|-----------|-------------|
+| AiObservability | `AI-APP-EVALUATORS:READ` | View the Application Eval Catalog. |
+| AiObservability | `AI-APP-EVALUATORS:MANAGE` | Add, edit, and delete evals for an application. |
+
+## Common error response codes
+
+| Status Code | Description                           |
+|-------------|---------------------------------------|
+| `400 Bad Request` | Response code 400 |
+| `401 Unauthorized` | Response code 401 |
+| `500 Internal Server Error` | Response code 500 |
+
+## Constants
+
+<details>
+  <summary>EvaluationType</summary>
+
+  | Value |
+|-------|
+| `ALLOWED_TOPICS` |
+| `COMPETITION` |
+| `HALLUCINATION_COMPLETENESS` |
+| `HALLUCINATION_CONTEXT_ADHERENCE` |
+| `HALLUCINATION_CONTEXT_RELEVANCE` |
+| `HALLUCINATION_CORRECTNESS` |
+| `HALLUCINATION_TASK_ADHERENCE` |
+| `PII` |
+| `PROMPT_INJECTION` |
+| `RESTRICTED_TOPICS` |
+| `SEXISM` |
+| `SQL_ALLOWED_TABLES` |
+| `SQL_HALLUCINATION` |
+| `SQL_LOAD` |
+| `SQL_READ_ONLY` |
+| `SQL_RESTRICTED_TABLES` |
+| `TOXICITY` |
+| `LANGUAGE_MISMATCH` |
+| `CUSTOM_EVALUATION` |
+</details>


### PR DESCRIPTION
## What

Adds service-overview pages for the two new v5 services that landed via the openapi-facade weekly sync:

- **AI Applications Service** — catalog of AI applications discovered from spans + company model pricing.
- **AI Evaluations Service** — AI evaluations and the custom evaluation catalog.

Their operation pages already existed (auto-generated from the spec) but had no overview. This adds:

- `service-overviews/ai-applications-service-overview.mdx`
- `service-overviews/ai-evaluations-service-overview.mdx`
- Two `V5_SERVICES` entries in `build_navigation_file.py`
- Regenerated `docs.json` (both services now in the v5 nav, overview first) + the copied `overview.mdx` under each `api-reference/v5/…` dir

## Notes for reviewers

- Permissions come from the documented **AiObservability** role preset (`AI-APP-CATALOG`, `AI-APP-DISCOVERY`, `AI-APP-EVALUATORS`). The new ops shipped **without `x-coralogixPermissions`** annotations in the facade — adding them upstream would let the reference surface permissions automatically.
- Companion PR in `coralogix/documentation` adds the matching developer-portal overview pages.
- Suggested reviewer / sign-off: Roni Sidon (AI Observability PM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)